### PR TITLE
Refactor text layer highlight handling

### DIFF
--- a/src/components/Layers/HighlightLayer.tsx
+++ b/src/components/Layers/HighlightLayer.tsx
@@ -1,41 +1,45 @@
-import React, { useMemo } from 'react';
-import useTextStore from '../../store/textStore';
+import React from 'react';
 
-type Props = { textDivs: HTMLElement[]; pageNum: number; };
+export interface HighlightGeometry {
+  id: string;
+  rect: {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  };
+  isActive: boolean;
+}
 
-const HighlightLayer: React.FC<Props> = ({ textDivs, pageNum }) => {
-  const { searchTerm, matchDivIndicesByPage, currentMatchIndex } = useTextStore();
-  const indices = matchDivIndicesByPage[pageNum] ?? [];
+type Props = { highlights: HighlightGeometry[] };
 
-  if (!searchTerm.trim() || indices.length === 0 || textDivs.length === 0) return null;
+const HighlightLayer: React.FC<Props> = ({ highlights }) => {
+  if (!highlights.length) return null;
 
-  const container = textDivs[0]?.closest('.text-layer') as HTMLElement | null;
-  const containerRect = container?.getBoundingClientRect();
-  if (!containerRect) return null;
-
-  const nodes = indices.map((i, k) => {
-    const rect = textDivs[i].getBoundingClientRect();
-    const isActive = k === currentMatchIndex;
-    return (
-      <div
-        key={`hl-${i}`}
-        className={`highlight ${isActive ? 'active' : ''}`}
-        style={{
-          position: 'absolute',
-          left: `${rect.left - containerRect.left}px`,
-          top: `${rect.top - containerRect.top}px`,
-          width: `${rect.width}px`,
-          height: `${rect.height}px`,
-          background: 'rgba(255, 235, 59, 0.45)',
-          outline: isActive ? '2px solid #f57c00' : 'none',
-          pointerEvents: 'none',
-          zIndex: 2,
-        }}
-      />
-    );
-  });
-
-  return <div className="highlight-layer" style={{ position: 'absolute', pointerEvents: 'none', zIndex: 2 }}>{nodes}</div>;
+  return (
+    <div
+      className="highlight-layer"
+      style={{ position: 'absolute', pointerEvents: 'none', zIndex: 2, inset: 0 }}
+    >
+      {highlights.map(({ id, rect, isActive }) => (
+        <div
+          key={id}
+          className={`highlight ${isActive ? 'active' : ''}`}
+          style={{
+            position: 'absolute',
+            left: `${rect.left}px`,
+            top: `${rect.top}px`,
+            width: `${rect.width}px`,
+            height: `${rect.height}px`,
+            background: 'rgba(255, 235, 59, 0.45)',
+            outline: isActive ? '2px solid #f57c00' : 'none',
+            pointerEvents: 'none',
+            zIndex: 2,
+          }}
+        />
+      ))}
+    </div>
+  );
 };
 
 export default HighlightLayer;


### PR DESCRIPTION
## Summary
- store rendered text divs inside a ref and drive highlight rendering from derived serializable data
- recompute search indices and highlight rectangles after text-layer renders without keeping DOM nodes in React state
- update the highlight layer component to render from highlight geometry data

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cf9886eec4832d9f5c9f94d989d743