### PR TITLE
Remove PDF viewer layout styles from global CSS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -33,20 +33,3 @@ body {
   flex-direction: column;
 }
 
-.controls {
-  padding: 8px;
-  background-color: #ffffff;
-  border-bottom: 1px solid #ddd;
-  display: flex;
-  gap: 8px;
-  align-items: center;
-}
-
-.viewer-container {
-  flex: 1;
-  overflow: auto;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: #e0e0e0;
-}


### PR DESCRIPTION
## Summary
- keep the PDF viewer layout styles scoped to the PDFViewer component
- remove the duplicate .controls and .viewer-container rules from the global stylesheet

## Testing
- npm run build *(fails: pdfjs-dist no longer exports renderTextLayer)*

------
https://chatgpt.com/codex/tasks/task_e_68cf9890d13c832da504ab13191ce51a