### PR TITLE
Add overlay opacity controls to PDF viewer overlays

### DIFF
--- a/src/components/PDFViewer/PDFViewer.css
+++ b/src/components/PDFViewer/PDFViewer.css
@@ -12,6 +12,33 @@
   overflow-y: auto;
 }
 
+.overlay-opacity-control {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+  font-size: 0.75rem;
+  color: #333333;
+}
+
+.overlay-opacity-control label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+}
+
+.overlay-opacity-control input[type="range"] {
+  width: 100%;
+  accent-color: #0070f3;
+  cursor: pointer;
+}
+
+.overlay-opacity-control input[type="range"]:focus-visible {
+  outline: 2px solid #005fcc;
+  outline-offset: 2px;
+}
+
 .pdf-thumbnails {
   list-style: none;
   padding: 0;

--- a/src/components/PDFViewer/PDFViewer.tsx
+++ b/src/components/PDFViewer/PDFViewer.tsx
@@ -23,6 +23,7 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file }) => {
   const [error, setError] = useState<string | null>(null); // 🔥 ERROR HANDLING: Add error state
   const [isLoading, setIsLoading] = useState(false); // 🔥 LOADING STATES: Add loading indicator
   const [isRendering, setIsRendering] = useState(false); // 🔥 LOADING STATES: Add rendering indicator
+  const [overlayOpacity, setOverlayOpacity] = useState(100);
 
   const loadDocument = useCallback(async () => {
     try {
@@ -152,6 +153,20 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file }) => {
     };
   }, [currentPage, scale, isDocumentLoaded, pdfDoc]);
 
+  useEffect(() => {
+    const textLayerEl = textLayerRef.current;
+    const hlLayerEl = hlLayerRef.current;
+    const opacityValue = overlayOpacity / 100;
+
+    if (textLayerEl) {
+      textLayerEl.style.opacity = `${opacityValue}`;
+    }
+
+    if (hlLayerEl) {
+      hlLayerEl.style.opacity = `${opacityValue}`;
+    }
+  }, [overlayOpacity, currentPage, isDocumentLoaded]);
+
   const goPrev = () => { if (currentPage > 1) setCurrentPage(currentPage - 1); };
   const goNext = () => { if (currentPage < pageCount) setCurrentPage(currentPage + 1); };
   const zoomIn = () => setScale(scale + 0.25);
@@ -185,6 +200,20 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file }) => {
   return (
     <div className="pdf-container">
       <nav className="pdf-sidebar">
+        <div className="overlay-opacity-control">
+          <label htmlFor="overlay-opacity">
+            Overlay opacity: <span>{overlayOpacity}%</span>
+          </label>
+          <input
+            id="overlay-opacity"
+            type="range"
+            min={0}
+            max={100}
+            step={10}
+            value={overlayOpacity}
+            onChange={(event) => setOverlayOpacity(Number(event.target.value))}
+          />
+        </div>
         <ul className="pdf-thumbnails">
           {isDocumentLoaded && pageCount > 0 ? (
             Array.from({ length: pageCount }, (_, i) => i + 1).map(page => (


### PR DESCRIPTION
## Summary
- add overlay opacity state that keeps text and highlight layers in sync with the selected transparency
- add an accessible sidebar range slider so users can adjust overlay opacity and read the current value
- style the new control to integrate with the thumbnail sidebar layout

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cfc8a96734832d963f81145f2394e0