### PR TITLE
Add text store tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "preview": "vite preview",
     "serve": "vite preview --port 4173",
     "type-check": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "vitest run"
   },
   "keywords": [
     "pdf",
@@ -52,6 +53,7 @@
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.1",
     "typescript": "^5.9.2",
-    "vite": "^7.1.3"
+    "vite": "^7.1.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/src/store/__tests__/textStore.test.ts
+++ b/src/store/__tests__/textStore.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import useTextStore from '../textStore';
+
+const resetStore = () => {
+  useTextStore.setState({
+    searchTerm: '',
+    matchDivIndicesByPage: {},
+    currentMatchIndex: -1,
+    currentPage: 1,
+  });
+};
+
+beforeEach(() => {
+  resetStore();
+});
+
+describe('setSearchTerm', () => {
+  it('normalizes the input and resets currentMatchIndex', () => {
+    useTextStore.setState({ currentMatchIndex: 3 });
+
+    useTextStore.getState().setSearchTerm('\u212B');
+
+    const { searchTerm, currentMatchIndex } = useTextStore.getState();
+    expect(searchTerm).toBe('\u00C5');
+    expect(currentMatchIndex).toBe(-1);
+  });
+});
+
+describe('setPageMatches', () => {
+  it('preserves the current index when still within the new range', () => {
+    useTextStore.getState().setPageMatches(1, [10, 20, 30]);
+    useTextStore.setState({ currentMatchIndex: 1 });
+
+    useTextStore.getState().setPageMatches(1, [40, 50, 60]);
+
+    const state = useTextStore.getState();
+    expect(state.matchDivIndicesByPage[1]).toEqual([40, 50, 60]);
+    expect(state.currentMatchIndex).toBe(1);
+  });
+
+  it('resets the index when the match list changes length', () => {
+    useTextStore.getState().setPageMatches(1, [1, 2, 3]);
+    useTextStore.setState({ currentMatchIndex: 2 });
+
+    useTextStore.getState().setPageMatches(1, [7]);
+    expect(useTextStore.getState().currentMatchIndex).toBe(0);
+
+    useTextStore.getState().setPageMatches(1, []);
+    expect(useTextStore.getState().currentMatchIndex).toBe(-1);
+  });
+});
+
+describe('navigation', () => {
+  it('wraps around for nextMatch and prevMatch', () => {
+    const { setPageMatches, nextMatch, prevMatch } = useTextStore.getState();
+
+    setPageMatches(1, [3, 4, 5]);
+    expect(useTextStore.getState().currentMatchIndex).toBe(0);
+
+    nextMatch();
+    expect(useTextStore.getState().currentMatchIndex).toBe(1);
+
+    nextMatch();
+    expect(useTextStore.getState().currentMatchIndex).toBe(2);
+
+    nextMatch();
+    expect(useTextStore.getState().currentMatchIndex).toBe(0);
+
+    prevMatch();
+    expect(useTextStore.getState().currentMatchIndex).toBe(2);
+  });
+
+  it('does nothing when the active page has no matches', () => {
+    const { setPageMatches, nextMatch, prevMatch } = useTextStore.getState();
+
+    setPageMatches(1, []);
+    expect(useTextStore.getState().currentMatchIndex).toBe(-1);
+
+    nextMatch();
+    expect(useTextStore.getState().currentMatchIndex).toBe(-1);
+
+    prevMatch();
+    expect(useTextStore.getState().currentMatchIndex).toBe(-1);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests covering the text store's search term normalization, page match updates, and navigation logic
- reset the zustand store state between tests to avoid leakage
- expose an npm test script and declare vitest as a dev dependency so the suite can run

## Testing
- npm test *(fails in this environment because vitest cannot be downloaded from the npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cfce33a760832db8d6ddba335de0cf